### PR TITLE
Create multiple cards for RT (RequestTracker) search results.

### DIFF
--- a/trello_bookmarklet.js
+++ b/trello_bookmarklet.js
@@ -89,7 +89,7 @@
                 cells = ticket.parents('tr').find('td');
                 owner = $(cells[owner_index]).text();
                 stat = $(cells[status_index]).text();
-                if (owner != 'Nobody' & ((stat == 'open') | (stat == 'offen'))) {
+                if (owner != 'Nobody' & ((stat == 'open') | (stat == 'offen') | (stat == 'neu') | (stat == 'new'))) {
                     if (!(owner in tickets)) {
                         tickets[owner] = {user: owner, tickets: []};
                     }


### PR DESCRIPTION
When looking at a RT search result, the script now creates one card for every user who has assigned RT tickets which are "open". A checklist with the tickets subjects and links is added to the cards.
The columns for ticket owner and status and subject needs to be there. 
