### PR TITLE
Limit height of dialog showing boards list, and add scrollbars

### DIFF
--- a/trello_bookmarklet.js
+++ b/trello_bookmarklet.js
@@ -260,7 +260,7 @@
         next(idList);
       } else {
         Trello.get("members/me/boards", { fields: "name" }, function(boards){
-          $prompt = overlayPrompt('Which list should cards be sent to?<hr><div class="boards"></div>', false, function(){
+          $prompt = overlayPrompt('Which list should cards be sent to?<hr><div class="boards" style="height:500px;overflow-y:scroll"></div>', false, function(){
             idList = $prompt.find("input:checked").attr("id");
             next(idList);
           })


### PR DESCRIPTION
Currently if you have many lists, you get a gigantic dialog showing all the lists in all the boards that overflows out of the screen with no scrollbars.

This limits the height (to arbitrary 500px) and ensures we have at least vertical scrolling.